### PR TITLE
Fixed event listener (7.0.2)

### DIFF
--- a/src/olympe/subscriber.py
+++ b/src/olympe/subscriber.py
@@ -55,11 +55,6 @@ class Subscriber:
         # elements as new elements are appended.
         self._event_queue = deque([], queue_size)
 
-        # Await the expectation, this prevent monitored command expectations
-        # from sending messages
-        if self._expectation is not None:
-            self._expectation._await(self._scheduler)
-
     def __enter__(self):
         pass
 
@@ -79,8 +74,7 @@ class Subscriber:
             if self._expectation.success() or self._expectation.cancelled():
                 # reset already succeeded or cancelled expectations
                 self._expectation = self._expectation.copy()
-                self._expectation._await(self._scheduler)
-            if not self._expectation.success() and self._expectation.check(event).success():
+            if self._expectation.check(event).success():
                 self._add_event(event)
                 return True
             else:
@@ -98,6 +92,3 @@ class Subscriber:
     @property
     def timeout(self):
         return self._timeout
-
-    def unsubscribe(self):
-        self._scheduler.unsubscribe(self)


### PR DESCRIPTION
With the new version of olympe 7.0.0 until 7.0.2 the event listener did not get any events. This is an example that it event for roll, pitch, yaw was never triggered:
```python
import olympe
from olympe.messages.ardrone3.PilotingState import AttitudeChanged
import time

class FlightListener(olympe.EventListener):

    @olympe.listen_event(AttitudeChanged())
    def AttitudeChange(self, event, scheduler):
        roll = event.args['roll']
        pitch = event.args['pitch']
        yaw = event.args['yaw']
        print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")

olympe.log.update_config({"loggers": {"olympe": {"level": "ERROR"}}})
SKYCTRL_IP = "192.168.53.1"
drone = olympe.Drone(SKYCTRL_IP)
drone.connect()
listener = FlightListener(drone)
listener.subscribe()

print(drone.get_state(AttitudeChanged))
while True:
    time.sleep(0.5)
```